### PR TITLE
BT-957 BT-958 UX fixes: simplify classifier details button, remove is default column, fix some IA issues with nav links, fix passthru tooltip hover

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,3 +3,8 @@
 @import "tailwindcss/utilities";
 
 /* This file is for your main application CSS */
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/lib/excision_web/components/layouts/app.html.heex
+++ b/lib/excision_web/components/layouts/app.html.heex
@@ -14,7 +14,7 @@
     </div>
     <div class="flex items-center gap-4 font-semibold leading-6 text-zinc-900">
       <a href="/" class="hover:text-zinc-700">
-        Decision Sites
+        All Decision Sites
       </a>
       <a href={~p"/swaggerui"} class="rounded-lg bg-zinc-100 px-2 py-1 hover:bg-zinc-200/80">
         API <span aria-hidden="true">&rarr;</span>

--- a/lib/excision_web/components/tooltip_component.ex
+++ b/lib/excision_web/components/tooltip_component.ex
@@ -16,7 +16,7 @@ defmodule ExcisionWeb.Components.TooltipComponent do
   def tooltip(assigns) do
     assigns =
       assign(assigns, :tooltip_classes, """
-        absolute z-10 invisible opacity-0 group-hover:visible group-hover:opacity-100
+        absolute z-10 invisible opacity-0 group-hover/passthrough-tooltip:visible group-hover/passthrough-tooltip:opacity-100
         #{assigns.width} min-h-[40px] max-h-[200px] overflow-y-auto
         bottom-full left-1/2 -translate-x-1/2 mb-3
         bg-gray-900/95 backdrop-blur-sm
@@ -28,7 +28,7 @@ defmodule ExcisionWeb.Components.TooltipComponent do
       """)
 
     ~H"""
-    <div class="relative inline-block group">
+    <div class="relative inline-block group/passthrough-tooltip">
       <div class="cursor-help">
         <.icon name="hero-question-mark-circle" class={@icon_class <> " " <> @class} />
       </div>

--- a/lib/excision_web/live/classifier_live/index.html.heex
+++ b/lib/excision_web/live/classifier_live/index.html.heex
@@ -1,5 +1,5 @@
 <.header>
-  Listing Classifiers for Decision Site <%= @decision_site.name %>
+  <%= @decision_site.name %> classifiers
   <:actions>
     <.link patch={~p"/decision_sites/#{@decision_site}/classifiers/new"}>
       <.button>New Classifier</.button>

--- a/lib/excision_web/live/classifier_live/index.html.heex
+++ b/lib/excision_web/live/classifier_live/index.html.heex
@@ -18,15 +18,15 @@
 >
   <:col :let={{_id, classifier}} label="Name">
     <%= classifier.name %>
+    <%= if classifier.id == @decision_site.default_classifier_id do %>
+      *
+    <% end %>
     <%= if Excision.Excisions.is_default_passthrough_classifier?(classifier) do %>
       <ExcisionWeb.Components.TooltipComponent.passthrough_classifier_tooltip />
     <% end %>
   </:col>
   <:col :let={{_id, classifier}} label="Status">
     <%= Excision.Excisions.Classifier.status_to_display_status(classifier.status) %>
-  </:col>
-  <:col :let={{_id, classifier}} label="Is Default?">
-    <%= classifier.id == @decision_site.default_classifier_id %>
   </:col>
   <:action :let={{_id, classifier}}>
     <.link phx-click={

--- a/lib/excision_web/live/classifier_live/index.html.heex
+++ b/lib/excision_web/live/classifier_live/index.html.heex
@@ -32,14 +32,7 @@
     <.link phx-click={
       JS.navigate(~p"/decision_sites/#{@decision_site}/classifiers/#{classifier}")
     }>
-      <%= case classifier.status do %>
-        <% x when x in [:waiting, :failed] and @enough_labels_to_train -> %>
-          Train
-        <% :trained when classifier.id != @decision_site.default_classifier_id -> %>
-          Promote
-        <% _ -> %>
-          Details
-      <% end %>
+      Details
     </.link>
   </:action>
   <:action :let={{id, classifier}}>

--- a/lib/excision_web/live/classifier_live/show.html.heex
+++ b/lib/excision_web/live/classifier_live/show.html.heex
@@ -33,7 +33,7 @@
       <.button>Decisions</.button>
     </.link>
     <.link :if={@classifier.status == :trained} phx-click="promote">
-      <.button>Promote</.button>
+      <.button disabled={@classifier.decision_site.default_classifier_id == @classifier.id}>Promote</.button>
     </.link>
   </:actions>
 </.header>

--- a/lib/excision_web/live/classifier_live/show.html.heex
+++ b/lib/excision_web/live/classifier_live/show.html.heex
@@ -1,6 +1,5 @@
 <.header>
-  Showing classifier <%= @classifier.id %> for decision site <%= @classifier.decision_site.name %>
-  <:subtitle>This is a classifier record from your database.</:subtitle>
+  <%= @classifier.decision_site.name %> / <%= @classifier.name %>
   <:actions>
     <.link
       patch={

--- a/lib/excision_web/live/classifier_live/show.html.heex
+++ b/lib/excision_web/live/classifier_live/show.html.heex
@@ -33,7 +33,9 @@
       <.button>Decisions</.button>
     </.link>
     <.link :if={@classifier.status == :trained} phx-click="promote">
-      <.button disabled={@classifier.decision_site.default_classifier_id == @classifier.id}>Promote</.button>
+      <.button disabled={@classifier.decision_site.default_classifier_id == @classifier.id}>
+        Promote
+      </.button>
     </.link>
   </:actions>
 </.header>

--- a/lib/excision_web/live/classifier_live/show.html.heex
+++ b/lib/excision_web/live/classifier_live/show.html.heex
@@ -7,7 +7,7 @@
       }
       phx-click={JS.push_focus()}
     >
-      <.button>Edit classifier</.button>
+      <.button>Edit</.button>
     </.link>
     <%= if Enum.member?([:waiting, :failed], @classifier.status) do %>
       <%= if @num_labels_for_site >= (1.0 / (1.0 - frac_train())) do %>

--- a/priv/static/assets/app.css
+++ b/priv/static/assets/app.css
@@ -2016,6 +2016,10 @@ button:disabled {
   cursor: not-allowed;
 }
 
+.hover\:visible:hover {
+  visibility: visible;
+}
+
 .hover\:cursor-pointer:hover {
   cursor: pointer;
 }
@@ -2087,6 +2091,10 @@ button:disabled {
   opacity: 0.4;
 }
 
+.hover\:opacity-100:hover {
+  opacity: 1;
+}
+
 .focus\:border-rose-400:focus {
   --tw-border-opacity: 1;
   border-color: rgb(251 113 133 / var(--tw-border-opacity));
@@ -2111,6 +2119,14 @@ button:disabled {
   visibility: visible;
 }
 
+.group\/tooltip:hover .group-hover\/tooltip\:visible {
+  visibility: visible;
+}
+
+.group\/passthrough-tooltip:hover .group-hover\/passthrough-tooltip\:visible {
+  visibility: visible;
+}
+
 .group:hover .group-hover\:bg-zinc-100 {
   --tw-bg-opacity: 1;
   background-color: rgb(244 244 245 / var(--tw-bg-opacity));
@@ -2131,6 +2147,14 @@ button:disabled {
 
 .group:hover .group-hover\:opacity-70 {
   opacity: 0.7;
+}
+
+.group\/tooltip:hover .group-hover\/tooltip\:opacity-100 {
+  opacity: 1;
+}
+
+.group\/passthrough-tooltip:hover .group-hover\/passthrough-tooltip\:opacity-100 {
+  opacity: 1;
 }
 
 .phx-submit-loading.phx-submit-loading\:opacity-75 {

--- a/priv/static/assets/app.css
+++ b/priv/static/assets/app.css
@@ -2011,6 +2011,11 @@ select {
 
 /* This file is for your main application CSS */
 
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .hover\:cursor-pointer:hover {
   cursor: pointer;
 }


### PR DESCRIPTION
- only show details button on the classifier list item, because "Train", "Promote" always clicked through to the details view and it would have caused to much refactoring to address the inconsistency any other way
- Remove the is default column in the classifier list view and replace with a star on the name
- Disable the promote button in the details view if the classifier is default/bc can't be promoted
- update the "Decision Sites" label on the right side of the tool bar to be "All Decision Sites" to differentiate it from the breadcrumbs. IMO the breadcrumbs are unintuitive bc sometimes the entry refers to the list view and sometimes to the details view, but the change to update them I think requires more discussion. So instead, I did this easier fix
- Fixed issue where the passthrough classifier tooltip appears on table row hover. Now it only appears on question mark hover
- simplify titles in the classifiers list and single classifier view

<img width="1715" alt="Screenshot 2024-11-10 at 9 26 43 AM" src="https://github.com/user-attachments/assets/7cca8152-0aee-4091-af86-89419270ff99">
<img width="1703" alt="Screenshot 2024-11-10 at 9 30 17 AM" src="https://github.com/user-attachments/assets/1ce3db8a-8003-48bc-acda-25532a0f991f">


